### PR TITLE
addressed issue with ts compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ secure.config.js
 tsconfig.tsbuildinfo
 
 /packages/**/dist
+/packages/**/types

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -8,6 +8,7 @@
     "coverage:ts": "nyc -r lcov -e .ts -x \"*.test.ts\" npm run test",
     "coverage:js": "nyc -r lcov -e .js -x \"*.spec.js\" npm run test",
     "compile": "tsc",
+    "clean": "tsc --build --clean",
     "test": "mocha \"./test/**/*.spec.js\"",
     "test:js": "mocha \"./test/**/*.spec.js\"",
     "test:ts": "mocha -r ts-node/register tests/**/*.spec.ts",

--- a/packages/core-sdk/tsconfig.json
+++ b/packages/core-sdk/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "ES2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "declaration": true,
+    "declarationDir": "./types",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
@@ -19,7 +20,6 @@
     "experimentalDecorators": true,
     "strictPropertyInitialization":false,
     "rootDir": "./src",
-    "outDir": "dist",                        /* Redirect output structure to the directory. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */


### PR DESCRIPTION
Switched typescript config to have files compile along side Js until `core-sdk` is fully converted to `ts`.

Have type definitions go in their own folder `types`.

Added new command for cleaning up after testing.